### PR TITLE
backend/hotfix/pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
         - cd backend
         - pip install -r requirements.txt
       script:
-        - pylint woondongjang/**/*.py --load-plugins pylint_django
+        - pylint woondongjang/**/*.py --load-plugins=pylint_django --django-settings-module=woondongjang.settings --disable=imported-auth-user,C,R
         - coverage run --source='.' woondongjang/manage.py test
         - coverage xml
         - cd .. && sonar-scanner

--- a/backend/.pylintrc
+++ b/backend/.pylintrc
@@ -45,8 +45,8 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=pylint_django
-django-settings-module = woondongjang.settings
+load-plugins=pylint_django # My option
+django-settings-module=woondongjang.settings # My option
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -86,7 +86,10 @@ disable=raw-checker-failed,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        use-symbolic-message-instead
+        use-symbolic-message-instead,
+        imported-auth-user, # My option
+        C, # My option
+        R # My option
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
pylint 메시지 타입에 C(convention), R(refactor), W(warning), E(error), F(fatal)가 있는데 C와 R은 disable 했어.

그리고 `from django.contrib.auth.models import User`에서 발생하는 E5142(imported-auth-user) 에러도 추가적으로 disable 했어. 왜냐하면 [User를 이렇게 사용](https://docs.djangoproject.com/en/3.2/topics/auth/customizing/#referencing-the-user-model)해야 에러가 발생하지 않는데, 그러면 코드 가독성이 떨어져.