### PR TITLE
Add default fonts

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -28,6 +28,17 @@
       type="text/javascript"
       src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_KEY%&libraries=services"
     ></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css"
+      rel="stylesheet"
+      type="text/css"
+    />
     <title>React App</title>
   </head>
   <body>

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -3,18 +3,8 @@
   height: 100vh;
 }
 
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+* {
+  font-family: 'Spoqa Han Sans Neo', 'Rubik', sans-serif;
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */


### PR DESCRIPTION
Rubik, Spoqa Han Sans 폰트 추가
전체 설정에서 언어별로 다른 폰트가 적용되게 하는 건 어려울 것 같아서
그때그때 한글 = Spoqa, 숫자 / 영어 = Rubik 으로 CSS 적용해줘야 할 듯합니다