### PR TITLE
frontend/hotfix/csrf-token

### DIFF
--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -6,10 +6,11 @@ urlpatterns = [
     path("signup", views.signup, name="signup"),
     path("signin", views.signin, name="signin"),
     path("signout", views.signout, name="signout"),
-    path("get/<int:user_id>", views.get_user_detail, name = "get_user_detail"),
+    path("get/<int:user_id>", views.get_user_detail, name="get_user_detail"),
     path("<int:user_id>", views.user_detail, name="user_detail"),
     path("<int:user_id>/notification", views.get_notification, name="get_notification"),
     path(
         "notification/<int:noti_id>", views.read_notification, name="read_notification"
     ),
+    path("csrftoken", views.set_csrftoken, name="set_csrftoken"),
 ]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_POST, require_GET, require_http_methods
+from django.views.decorators.csrf import ensure_csrf_cookie
 from posts.models import Exercise, User_Exercise, Post, Participation
 from .models import Notification, Profile, ProxyUser
 from .decorators import signin_required
@@ -220,3 +221,10 @@ def read_notification(request, noti_id):
         )
     ]
     return JsonResponse(noti_list, status=200, safe=False)
+
+
+# 응답 헤더 Set-Cookie: csrftoken=...
+@require_GET
+@ensure_csrf_cookie
+def set_csrftoken(request):
+    return HttpResponse(status=204)

--- a/backend/woondongjang/settings.py
+++ b/backend/woondongjang/settings.py
@@ -50,7 +50,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    # "django.middleware.csrf.CsrfViewMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -154,7 +154,10 @@ LOGGING = {
     },
 }
 
+# 응답 헤더 Acces-Control-Allow-Origin
 CORS_ALLOW_ALL_ORIGINS = True
+# Cross-site로부터 요청 헤더 Cookie 받는 것 허용
+# 응답 헤더 Acces-Control-Allow-Credentials
 CORS_ALLOW_CREDENTIALS = True
 
 secrets_file = os.path.join(BASE_DIR, "secrets.json")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,8 @@ axios.defaults.baseURL = 'http://127.0.0.1:8000';
 axios.defaults.xsrfCookieName = 'csrftoken';
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 
+axios.get('/users/csrftoken');
+
 const App = ({ history }: { history: History }) => {
   const dispatch = useDispatch();
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,7 +19,11 @@ import { AppState } from './store/store';
 import { autoSignin } from './store/actions/user';
 
 axios.defaults.baseURL = 'http://127.0.0.1:8000';
+// Cross-site에 요청 헤더 Cookie 보내는 것 허용
+axios.defaults.withCredentials = true;
+// 요청 헤더 Cookie: csrftoken=...
 axios.defaults.xsrfCookieName = 'csrftoken';
+// 요청 헤더 X-CSRFToken: ...
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 
 axios.get('/users/csrftoken');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import Navbar from './containers/Navbar';
 import { AppState } from './store/store';
 import { autoSignin } from './store/actions/user';
 
-axios.defaults.baseURL = 'http://127.0.0.1:8000';
+axios.defaults.baseURL = 'http://localhost:8000';
 // Cross-site에 요청 헤더 Cookie 보내는 것 허용
 axios.defaults.withCredentials = true;
 // 요청 헤더 Cookie: csrftoken=...

--- a/frontend/src/utils/getGuDong.ts
+++ b/frontend/src/utils/getGuDong.ts
@@ -14,6 +14,9 @@ const getGuDong = async (x: number, y: number) => {
         x,
         y,
       },
+      // App.tsx의 글로벌 설정 오버라이드
+      // true이면 CORS 정책 위반
+      withCredentials: false,
     });
     const { region_2depth_name, region_3depth_name } =
       response.data.documents[1];


### PR DESCRIPTION
Cross-site 쿠키 허용하려고 axios 글로벌 설정을 `withCredentials = true`로 바꿨어.

그런데 카카오 API 호출할 땐 예외적으로 `false`로 했어.
`true`면 preflight 요청에 대한 응답 헤더가 `Access-Control-Allow-Origin: *`라서 CORS 정책 위반이야.
<img width="1116" alt="Screen Shot 2021-12-13 at 5 05 06 PM" src="https://user-images.githubusercontent.com/90981157/145792942-fcdcdbc4-79e6-48af-80ef-f3a7b5bc614e.png">
<img width="428" alt="Screen Shot 2021-12-13 at 5 08 08 PM" src="https://user-images.githubusercontent.com/90981157/145792954-66a6eb8b-bcb5-4629-a717-37b9049a9711.png">
