### PR TITLE
Frontend/hotfix/post edit

### DIFF
--- a/backend/posts/models.py
+++ b/backend/posts/models.py
@@ -150,7 +150,6 @@ class Post(models.Model):
     place_telephone = models.CharField(max_length=20)
     min_capacity = models.IntegerField()
     max_capacity = models.IntegerField()
-    member_count = models.IntegerField(default=0)
     kakaotalk_link = models.CharField(max_length=256)
     status = models.CharField(
         max_length=10, choices=Status.choices, default=Status.RECRUITING

--- a/backend/posts/models.py
+++ b/backend/posts/models.py
@@ -150,6 +150,7 @@ class Post(models.Model):
     place_telephone = models.CharField(max_length=20)
     min_capacity = models.IntegerField()
     max_capacity = models.IntegerField()
+    member_count = models.IntegerField(default=0)
     kakaotalk_link = models.CharField(max_length=256)
     status = models.CharField(
         max_length=10, choices=Status.choices, default=Status.RECRUITING

--- a/backend/posts/views.py
+++ b/backend/posts/views.py
@@ -40,7 +40,7 @@ def get_posts(request):
             },
             "min_capacity": post.min_capacity,
             "max_capacity": post.max_capacity,
-            "member_count": post.member_count,
+            "member_count": post.participation_set.filter(status='ACCEPTED').count(),
             "kakaotalk_link": post.kakaotalk_link,
             "status": post.status,
             "keywords": [
@@ -124,7 +124,7 @@ def post_posts(request):
         },
         "max_capacity": new_post.max_capacity,
         "min_capacity": new_post.min_capacity,
-        "member_count": new_post.member_count,
+        "member_count": 0,
         "kakaotalk_link": new_post.kakaotalk_link,
         "status": new_post.status,
         "keywords": keyword_list,
@@ -163,7 +163,7 @@ def get_post_detail(request, post_id=0):
         "meet_at": post.meet_at_res,
         "max_capacity": post.max_capacity,
         "min_capacity": post.min_capacity,
-        "member_count": post.member_count,
+        "member_count": post.participation_set.filter(status='ACCEPTED').count(),
         "place": {
             "latitude": post.latitude,
             "longitude": post.longitude,
@@ -351,8 +351,6 @@ def apply(request, post_id):
 def accept(request, post_id, participant_id):
     # Post 조회
     post = get_object_or_404(Post, id=post_id)
-    count = post.member_count
-    print(count)
 
     # User(participant) 조회
     participant = get_object_or_404(User, id=participant_id)
@@ -361,8 +359,6 @@ def accept(request, post_id, participant_id):
     Participation.objects.filter(user=participant, post=post).update(
         status=Participation.Status.ACCEPTED
     )
-
-    Post.objects.filter(id=post_id).update(member_count=count + 1)
 
     # Notification 생성
     Notification.objects.create(

--- a/frontend/src/backend/api/api.ts
+++ b/frontend/src/backend/api/api.ts
@@ -43,7 +43,7 @@ export const updateProfile = produceUpdateAPI<UpdateProfileDTO>('/users');
 export const queryFilterPosts = async (
   filterString: string,
 ): Promise<queryReturnType<PostEntity>> => {
-  const res = await axios.get(`/posts/?${filterString}`);
+  const res = await axios.get(`/posts/get?${filterString}`);
   return { items: humps.camelizeKeys(res.data) as PostEntity[] };
 };
 

--- a/frontend/src/components/PostDetail/index.scss
+++ b/frontend/src/components/PostDetail/index.scss
@@ -20,6 +20,7 @@
   #body-1 {
     display: flex;
     margin-bottom: 40px;
+    height: 360px;
 
     #left {
       flex-basis: 50%;

--- a/frontend/src/containers/PostDetail/index.tsx
+++ b/frontend/src/containers/PostDetail/index.tsx
@@ -53,6 +53,8 @@ const PostDetailContainer: React.FC = () => {
     }
   };
 
+  console.log(postItem);
+
   const onPostDelete = async () => {
     await deletePost({ id: postId });
     history.push('/main');
@@ -106,19 +108,13 @@ const PostDetailContainer: React.FC = () => {
 
   useEffect(() => {
     if (postItem && loginUserId) {
+      // 참가 신청자 목록을 보여줌
       setParticipants(
         postItem.participants.filter(
           (participant) => participant.status !== 'DECLINED',
         ),
       );
-    }
-  }, [postItem]);
-
-  useEffect(() => {
-    if (loginUserId) {
-      const found = participants.find(
-        (participant) => participant.userId === loginUserId,
-      );
+      const found = postItem.participants.find((c) => c.userId === loginUserId);
       if (found) {
         setIsParticipant(true);
         if (found.status === 'PENDING') setApplyStatus(ApplyStatus.PENDING);
@@ -126,7 +122,7 @@ const PostDetailContainer: React.FC = () => {
         if (found.status === 'DECLINED') setApplyStatus(ApplyStatus.DECLINED);
       }
     }
-  }, [participants]);
+  }, [postItem]);
 
   // Render Component
   if (postItem === undefined) return null;

--- a/frontend/src/containers/PostEdit/index.test.tsx
+++ b/frontend/src/containers/PostEdit/index.test.tsx
@@ -7,6 +7,7 @@ import * as API from '../../backend/api/api';
 import PostEdit from '.';
 import mockStore from '../../store/store';
 
+const mockGoBack = jest.fn();
 const mockPush = jest.fn();
 const useStateMock = jest.spyOn(React, 'useState');
 const setPostMock = jest.fn();
@@ -41,7 +42,7 @@ const mockPost = {
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
-  useHistory: () => ({ push: mockPush }),
+  useHistory: () => ({ goBack: mockGoBack, push: mockPush }),
   useParams: () => ({ id: '1' }),
 }));
 

--- a/frontend/src/containers/PostEdit/index.tsx
+++ b/frontend/src/containers/PostEdit/index.tsx
@@ -76,7 +76,9 @@ const PostEdit: React.FC = () => {
       const cancelConfirm = confirm(
         '수정 사항이 있습니다. 정말 취소하시겠습니까?',
       );
-      if (cancelConfirm) history.push(`/post/${postId}`);
+      if (cancelConfirm) history.goBack();
+    } else {
+      history.goBack();
     }
   };
 


### PR DESCRIPTION
- ~~`post` 모델 `member_count` 필드를 없애고~~ (테스트 통과가 안 돼서 모델은 그대로 뒀습니다) 해당 게시글에 대해 생성된 `participation` 개수를 `count` 해서 사용
#120 

- `PostEdit` 컨테이너에서 취소 버튼이 눌리지 않는 에러 해결 #169 
- `queryFilter` 에러 해결
- `PostDetail` 컴포넌트 CSS 수정